### PR TITLE
Implement #4

### DIFF
--- a/bin/_mb.bat
+++ b/bin/_mb.bat
@@ -55,7 +55,7 @@ set PROMPT=$$
 pushd %PROJECTS%
 
 :: Clear screen
-title Mindbender Pipeline
+title Mindbender Launcher
 cls
 
 :: Print intro

--- a/bin/_mkproject.bat
+++ b/bin/_mkproject.bat
@@ -16,6 +16,10 @@
 @echo off
 
 if "%1"=="" goto :missing_projectdir
+if not "%3"=="assets" (
+  if not "%3"=="film" goto :missing_stage
+)
+
 if "%2"=="" goto :missing_name
 if "%3"=="" goto :missing_stage
 
@@ -30,6 +34,9 @@ if not exist %PROJECTDIR% (
 )
 
 pushd %PROJECTDIR%\%3
+
+:: Clear screen
+cls
 
 echo+
 echo  ASSETS -----------
@@ -56,7 +63,13 @@ goto :eof
 :missing_projectdir
 	exit /b
 :missing_stage
-    echo Assets or Film?
+    echo  Uh oh..
+    echo    Specify either "assets" or "film"
+    echo+
+    echo  Example:
+    set temp=%2
+    echo    $ %temp% assets
+    echo    $ %temp% film
     exit /b
 
 echo+

--- a/mindbender/plugins/validate_model_hierarchy.py
+++ b/mindbender/plugins/validate_model_hierarchy.py
@@ -2,9 +2,9 @@ import pyblish.api
 
 
 class ValidateMindbenderModelHierarchy(pyblish.api.InstancePlugin):
-    """A model hierarchy must reside under a single assembly called "model_GRP"
+    """A model hierarchy must reside under a single assembly called "ROOT"
 
-    - Must reside within `model_GRP` transform
+    - Must reside within `ROOT` transform
 
     """
 
@@ -16,5 +16,5 @@ class ValidateMindbenderModelHierarchy(pyblish.api.InstancePlugin):
     def process(self, instance):
         from maya import cmds
 
-        assert cmds.ls(instance, assemblies=True) == ["model_GRP"], (
-            "Model must have a single parent called 'model_GRP'.")
+        assert cmds.ls(instance, assemblies=True) == ["ROOT"], (
+            "Model must have a single parent called 'ROOT'.")

--- a/mindbender/plugins/validate_rig_hierarchy.py
+++ b/mindbender/plugins/validate_rig_hierarchy.py
@@ -2,9 +2,9 @@ import pyblish.api
 
 
 class ValidateMindbenderRigHierarchy(pyblish.api.InstancePlugin):
-    """A rig must reside under a single assembly called "rig_GRP"
+    """A rig must reside under a single assembly called "ROOT"
 
-    - Must reside within `rig_GRP` transform
+    - Must reside within `ROOT` transform
 
     """
 
@@ -16,5 +16,5 @@ class ValidateMindbenderRigHierarchy(pyblish.api.InstancePlugin):
     def process(self, instance):
         from maya import cmds
 
-        assert cmds.ls(instance, assemblies=True) == ["rig_GRP"], (
-            "Rig must have a single parent called 'rig_GRP'.")
+        assert cmds.ls(instance, assemblies=True) == ["ROOT"], (
+            "Rig must have a single parent called 'ROOT'.")

--- a/mindbender/plugins/validate_rig_members.py
+++ b/mindbender/plugins/validate_rig_members.py
@@ -5,10 +5,10 @@ class ValidateMindbenderRigFormat(pyblish.api.InstancePlugin):
     """A rig must have a certain hierarchy and members
 
     - Must reside within `rig_GRP` transform
-    - out_SEL
-    - controls_SEL
-    - in_SEL (optional)
-    - resources_SEL (optional)
+    - out_SET
+    - controls_SET
+    - in_SET (optional)
+    - resources_SET (optional)
 
     """
 


### PR DESCRIPTION
Catch spelling, and make sure either "film" OR "assets" is typed. Anything else brings the user to an example of what to type.

This also updates the model and rig layout conventions used.